### PR TITLE
Fix: plugin service logs never reach the Jellyfin log

### DIFF
--- a/Server/AmbilightEntryPoint.cs
+++ b/Server/AmbilightEntryPoint.cs
@@ -31,6 +31,7 @@ namespace Jellyfin.Plugin.Ambilight.Server;
 public class AmbilightEntryPoint : IHostedService
 {
     private readonly ILogger<AmbilightEntryPoint> _logger;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly ILibraryManager _libraryManager;
     private readonly ISessionManager _sessionManager;
     private readonly IApplicationPaths _appPaths;
@@ -49,11 +50,13 @@ public class AmbilightEntryPoint : IHostedService
 
     public AmbilightEntryPoint(
         ILogger<AmbilightEntryPoint> logger,
+        ILoggerFactory loggerFactory,
         ILibraryManager libraryManager,
         ISessionManager sessionManager,
         IApplicationPaths appPaths)
     {
         _logger = logger;
+        _loggerFactory = loggerFactory;
         _libraryManager = libraryManager;
         _sessionManager = sessionManager;
         _appPaths = appPaths;
@@ -68,12 +71,13 @@ public class AmbilightEntryPoint : IHostedService
         
         Instance = this;
         
-        // Create logger factory for services (we're already using Microsoft.Extensions.Logging)
-        var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-        var storageLogger = loggerFactory.CreateLogger<AmbilightStorageService>();
-        var extractorLogger = loggerFactory.CreateLogger<AmbilightExtractorService>();
-        var playbackLogger = loggerFactory.CreateLogger<AmbilightPlaybackService>();
-        var extractorCoreLogger = loggerFactory.CreateLogger<AmbilightInProcessExtractor>();
+        // Use Jellyfin's injected logger factory so service logs reach the server log file
+        // and the dashboard log viewer. Creating a factory here (e.g. LoggerFactory.Create)
+        // would build a private pipeline whose output only ever lands on raw stdout.
+        var storageLogger = _loggerFactory.CreateLogger<AmbilightStorageService>();
+        var extractorLogger = _loggerFactory.CreateLogger<AmbilightExtractorService>();
+        var playbackLogger = _loggerFactory.CreateLogger<AmbilightPlaybackService>();
+        var extractorCoreLogger = _loggerFactory.CreateLogger<AmbilightInProcessExtractor>();
 
         _storage = new AmbilightStorageService(storageLogger, _config);
         _storage.CleanupStuckExtractions();

--- a/Tasks/ExtractPendingAmbilightTask.cs
+++ b/Tasks/ExtractPendingAmbilightTask.cs
@@ -25,17 +25,20 @@ namespace Jellyfin.Plugin.Ambilight.Tasks;
 public class ExtractPendingAmbilightTask : IScheduledTask
 {
     private readonly ILogger<ExtractPendingAmbilightTask> _logger;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly ILibraryManager _libraryManager;
     private readonly PluginConfiguration _config;
-    
+
     private AmbilightStorageService? _storage;
     private AmbilightExtractorService? _extractor;
 
     public ExtractPendingAmbilightTask(
         ILogger<ExtractPendingAmbilightTask> logger,
+        ILoggerFactory loggerFactory,
         ILibraryManager libraryManager)
     {
         _logger = logger;
+        _loggerFactory = loggerFactory;
         _libraryManager = libraryManager;
         _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     }
@@ -57,10 +60,11 @@ public class ExtractPendingAmbilightTask : IScheduledTask
         // Initialize services if needed
         if (_storage == null || _extractor == null)
         {
-            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            var storageLogger = loggerFactory.CreateLogger<AmbilightStorageService>();
-            var extractorLogger = loggerFactory.CreateLogger<AmbilightExtractorService>();
-            var extractorCoreLogger = loggerFactory.CreateLogger<AmbilightInProcessExtractor>();
+            // Use Jellyfin's injected logger factory (see AmbilightEntryPoint) so extraction
+            // logs reach the server log rather than a private stdout-only pipeline.
+            var storageLogger = _loggerFactory.CreateLogger<AmbilightStorageService>();
+            var extractorLogger = _loggerFactory.CreateLogger<AmbilightExtractorService>();
+            var extractorCoreLogger = _loggerFactory.CreateLogger<AmbilightInProcessExtractor>();
 
             _storage = new AmbilightStorageService(storageLogger, Config);
             var extractorCore = new AmbilightInProcessExtractor(extractorCoreLogger, Config);


### PR DESCRIPTION
## Problem

None of the Ambilight service logs appear in Jellyfin's log file or in Dashboard → Logs. They are only written to the server process's raw stdout - visible via `docker logs` on container installs, and easily missed entirely otherwise. Turning on the plugin's **Debug** setting doesn't help, because the messages are going to the wrong destination rather than being filtered out.

This makes the plugin hard to troubleshoot, since the diagnostics that explain why an ambilight session didn't start - no device mapping matched, binary not found, which WLED target was resolved, broadcast progress - are all emitted by the affected services.

## Cause

`AmbilightEntryPoint` and `ExtractPendingAmbilightTask` each build their own logger factory:

```csharp
var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
var playbackLogger = loggerFactory.CreateLogger<AmbilightPlaybackService>();
```

That creates a logging pipeline entirely independent of the one Jellyfin configures, with two consequences:

1. Its only sink is the console provider, so output goes to stdout and never reaches Jellyfin's configured sinks (log file, dashboard viewer).
2. `LoggerFactory.Create` defaults to a minimum level of `Information`, so every `LogDebug` call is discarded regardless of the server's configured log level.

This affects `AmbilightStorageService`, `AmbilightExtractorService`, `AmbilightPlaybackService`, `AmbilightInProcessExtractor`, and `AmbilightInProcessPlayer` (which receives its logger from the playback service).

Only `AmbilightEntryPoint`'s own `ILogger<AmbilightEntryPoint>` behaved correctly, because it comes from DI, which is why `[Ambilight] Background service starting...` shows up in the Jellyfin log while nothing else does.

## Fix

Both classes now receive `ILoggerFactory` through constructor injection and create their per-service loggers from it. Both are already DI-activated, so no service registration changes were required.

Service output now follows Jellyfin's configured sinks and log levels, and `LogDebug` calls are emitted when the server log level is set to Debug.

## Testing

- `dotnet build -c Release` succeeds with 0 warnings, 0 errors.
- The pre-fix behaviour was reproduced on a 10.11.6 Docker deployment: service logs appeared only in container stdout and were absent from both the Jellyfin log file and Dashboard → Logs, while `[Ambilight] Background service starting...` (the one correctly-injected logger) appeared in both.