### PR TITLE
feat: add per-device signal delay to WLED mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Jellyfin Ambilight Plugin will be documented in this 
 
 ## [Unreleased]
 
+### Added
+- **Per-device signal delay** — New signed `Signal Delay (ms)` setting on each WLED device mapping. Positive values delay the ambilight data (LEDs react later); negative values advance it (LEDs react earlier). Applied on top of the global sync lead to fine-tune sync issues on a specific device.
+
 ## [2.4.2] - 2026-07-22
 
 ### Fixed

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -697,6 +697,10 @@ the Free Software Foundation, either version 3 of the License, or
                         <label style="display: block; margin-bottom: 0.25em; font-size: 0.9em; opacity: 0.8;">Input Position</label>
                         <input type="number" class="mapping-input-pos emby-input" min="0" is="emby-input" />
                     </div>
+                    <div>
+                        <label style="display: block; margin-bottom: 0.25em; font-size: 0.9em; opacity: 0.8;">Signal Delay (ms)</label>
+                        <input type="number" class="mapping-signal-delay emby-input" step="1" is="emby-input" />
+                    </div>
                 `;
                 
                 wrapper.appendChild(ledConfig);
@@ -753,6 +757,7 @@ the Free Software Foundation, either version 3 of the License, or
                 wrapper.querySelector('.mapping-left').value = mapping.LeftLedCount || 49;
                 wrapper.querySelector('.mapping-right').value = mapping.RightLedCount || 49;
                 wrapper.querySelector('.mapping-input-pos').value = mapping.InputPosition || 0;
+                wrapper.querySelector('.mapping-signal-delay').value = mapping.SignalDelayMs || 0;
                 wrapper.querySelector('.mapping-gap-length').value = gapLength;
                 wrapper.querySelector('.mapping-gap-position').value = gapPosition;
             }
@@ -806,6 +811,7 @@ the Free Software Foundation, either version 3 of the License, or
                                 LeftLedCount: parseInt(row.querySelector('.mapping-left').value) || 49,
                                 RightLedCount: parseInt(row.querySelector('.mapping-right').value) || 49,
                                 InputPosition: parseInt(row.querySelector('.mapping-input-pos').value) || 0,
+                                SignalDelayMs: parseInt(row.querySelector('.mapping-signal-delay').value) || 0,
                                 GapLength: parseInt(row.querySelector('.mapping-gap-length').value) || 0,
                                 GapPosition: parseInt(row.querySelector('.mapping-gap-position').value) || 0
                             });

--- a/PluginConfiguration.cs
+++ b/PluginConfiguration.cs
@@ -99,5 +99,12 @@ namespace Jellyfin.Plugin.Ambilight
         public int InputPosition { get; set; } = 0;
         public int GapLength { get; set; } = 0;
         public int GapPosition { get; set; } = 0;
+
+        /// <summary>
+        /// Signed fine-tuning offset, in milliseconds, for the ambilight data sent to this WLED device.
+        /// Positive values delay the data (LEDs react later); negative values advance it (LEDs react earlier).
+        /// Applied on top of the global sync lead to correct per-device sync issues.
+        /// </summary>
+        public int SignalDelayMs { get; set; } = 0;
     }
 }

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Configure which Jellyfin devices should trigger ambilight effects and where to s
      - continue clockwise around the screen
    - **Gap Length** - Number of inactive LEDs at the gap position (include in the corresponding edge's LED count). Set to0 for no gap.
    - **Gap Position** - LED index where the gap starts, counting from 0 at top-left, clockwise (same coordinate system as Input Position). For example, if Top=50 and Right=25, the start of the bottom edge is index75.
+   - **Signal Delay (ms)** - Signed fine-tuning offset in milliseconds for the ambilight data sent to this WLED device. Positive values delay the data (LEDs react later); negative values advance it (LEDs react earlier). Applied on top of the global sync lead to correct per-device sync issues.
 5. **Save** - Click the Save button at the bottom
 6. **Repeat** - Add more mappings as needed
 

--- a/Services/AmbilightInProcessPlayer.cs
+++ b/Services/AmbilightInProcessPlayer.cs
@@ -448,7 +448,11 @@ public sealed class AmbilightInProcessPlayer : IDisposable
                 _logger.LogInformation("[Ambilight] Connected to WLED at {Host}:{Port}", mapping.Host, WledUdpPort);
             }
 
-            double baseSyncLead = cfg.AmbilightSyncLeadSeconds;
+            // Global sync lead runs the player ahead of the video. The per-mapping signal delay
+            // fine-tunes this for a single WLED device: a positive delay makes the LEDs react
+            // later (reduce the lead), a negative value makes them react earlier (increase it).
+            double signalDelaySeconds = mapping.SignalDelayMs / 1000.0;
+            double baseSyncLead = cfg.AmbilightSyncLeadSeconds - signalDelaySeconds;
             double effectiveStart = Math.Max(0.0, startSeconds + baseSyncLead);
             ulong startTsUs = (ulong)(effectiveStart * 1_000_000.0);
             int startFrame = 0;


### PR DESCRIPTION
Add a signed Signal Delay (ms) setting to each WLED device mapping. Positive values delay the ambilight data (LEDs react later); negative values advance it (LEDs react earlier). The offset is folded into the existing global sync lead in the in-process player, so it applies consistently to initial frame selection, seeks, and reported position.