### PR TITLE
feat: add selectable extraction logic (linear-light averaging)

### DIFF
--- a/Api/AmbilightController.cs
+++ b/Api/AmbilightController.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Ambilight.Server;
 using Jellyfin.Plugin.Ambilight.Services;
+using Jellyfin.Plugin.Ambilight.Services.Extraction;
 using Jellyfin.Plugin.Ambilight.Tasks;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Tasks;
@@ -144,6 +145,9 @@ public class AmbilightController : ControllerBase
                     binaryFormat = BinaryFormatDetector.DetectFormat(binPath);
                 }
 
+                // Extraction logic is stored in the AMb3 header, so read it from the file.
+                string? extractionLogicName = BinaryFormatDetector.DetectExtractionLogic(binPath);
+
                 results[itemId] = new AmbilightStatusResponse
                 {
                     ItemId = guid,
@@ -155,7 +159,8 @@ public class AmbilightController : ControllerBase
                     ExtractionProgress = extractionProgress,
                     ExtractionFramesCurrent = extractionFramesCurrent,
                     ExtractionFramesTotal = extractionFramesTotal,
-                    BinaryFormat = binaryFormat
+                    BinaryFormat = binaryFormat,
+                    ExtractionLogic = extractionLogicName
                 };
             }
 
@@ -263,6 +268,9 @@ public class AmbilightController : ControllerBase
                 binaryFormat = BinaryFormatDetector.DetectFormat(binPath);
             }
 
+            // Extraction logic is stored in the AMb3 header, so read it from the file.
+            string? extractionLogicName = BinaryFormatDetector.DetectExtractionLogic(binPath);
+
             var status = new AmbilightStatusResponse
             {
                 ItemId = guid,
@@ -274,7 +282,8 @@ public class AmbilightController : ControllerBase
                 ExtractionProgress = extractionProgress,
                 ExtractionFramesCurrent = extractionFramesCurrent,
                 ExtractionFramesTotal = extractionFramesTotal,
-                BinaryFormat = binaryFormat
+                BinaryFormat = binaryFormat,
+                ExtractionLogic = extractionLogicName
             };
 
             return Ok(status);
@@ -511,6 +520,12 @@ public class AmbilightStatusResponse
     public ulong ExtractionFramesCurrent { get; set; }
     public ulong ExtractionFramesTotal { get; set; }
     public string? BinaryFormat { get; set; }
+
+    /// <summary>
+    /// Human-readable name of the extraction logic that produced the binary (AMb3 only), e.g.
+    /// "Sobel edge-weighted" or "Linear-light averaging". Null for non-AMb3 or missing files.
+    /// </summary>
+    public string? ExtractionLogic { get; set; }
 }
 
 public class AmbilightExtractResponse
@@ -556,5 +571,15 @@ internal static class BinaryFormatDetector
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Reads the extraction-logic name from an AMb3 file header. Returns null for non-AMb3 or
+    /// missing files. Files predating the field read back as the default edge-weighted logic.
+    /// </summary>
+    public static string? DetectExtractionLogic(string binPath)
+    {
+        var code = Amb3Format.ReadExtractionLogic(binPath);
+        return code == null ? null : ExtractionLogicFactory.DisplayName(code.Value);
     }
 }

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -285,6 +285,7 @@ the Free Software Foundation, either version 3 of the License, or
                                     <th>Added Date</th>
                                     <th>Status</th>
                                     <th>Format</th>
+                                    <th>Logic</th>
                                     <th>Size</th>
                                     <th>Action</th>
                                 </tr>
@@ -1181,7 +1182,7 @@ the Free Software Foundation, either version 3 of the License, or
                             extractPendingBtnHtml = '<button is="emby-button" class="emby-button raised btnExtractPending" data-scope="series" data-id="' + seriesId + '" style="margin-left: 10px; padding: 0.2em 0.5em; font-size: 0.8em; z-index: 10; float: right;">Extract all pending</button>';
                         }
                         
-                        seriesRow.innerHTML = '<td colspan="5"><span class="material-icons" style="vertical-align: middle; font-size: 1.2em;">' + seriesExpandIcon + '</span> ' + 
+                        seriesRow.innerHTML = '<td colspan="6"><span class="material-icons" style="vertical-align: middle; font-size: 1.2em;">' + seriesExpandIcon + '</span> ' +
                             escapeHtml(series.name) + seriesStatusHtml + seriesStatsHtml + extractPendingBtnHtml + '</td>';
                         seriesRow.setAttribute('data-series-id', seriesCollapsedId);
                         seriesRow.setAttribute('data-collapsed', isSeriesCollapsed ? 'true' : 'false');
@@ -1237,7 +1238,7 @@ the Free Software Foundation, either version 3 of the License, or
                                 seasonExtractPendingBtnHtml = '<button is="emby-button" class="emby-button raised btnExtractPending" data-scope="season" data-id="' + seasonId + '" style="margin-left: 10px; padding: 0.2em 0.5em; font-size: 0.8em; z-index: 10; float: right;">Extract Season ' + seasonNumber + ' pending</button>';
                             }
                             
-                            seasonRow.innerHTML = '<td colspan="5"><span style="padding-left: 1.5em;"><span class="material-icons" style="vertical-align: middle; font-size: 1.2em;">' + seasonExpandIcon + '</span> ' + 
+                            seasonRow.innerHTML = '<td colspan="6"><span style="padding-left: 1.5em;"><span class="material-icons" style="vertical-align: middle; font-size: 1.2em;">' + seasonExpandIcon + '</span> ' +
                                 seasonName + seasonStatusHtml + seasonStatsHtml + '</span>' + seasonExtractPendingBtnHtml + '</td>';
                             seasonRow.setAttribute('data-season-id', seasonId);
                             seasonRow.setAttribute('data-collapsed', isSeasonCollapsed ? 'true' : 'false');
@@ -1524,10 +1525,16 @@ the Free Software Foundation, either version 3 of the License, or
                     formatText = '<span style="text-transform:uppercase;font-weight:bold;font-size:0.85em;color:#9ca3af;">' + escapeHtml(status.BinaryFormat) + '</span>';
                 }
 
+                var logicText = '-';
+                if (status && status.HasBinary && status.ExtractionLogic) {
+                    logicText = '<span style="font-size:0.85em;color:#9ca3af;" title="Extraction logic used for this binary">' + escapeHtml(status.ExtractionLogic) + '</span>';
+                }
+
                 var trContent = '<td style="padding-top:1em;padding-bottom:1em;">' + titleCellHtml + '</td>' +
                     '<td>' + addedDateText + '</td>' +
                     '<td>' + statusHtml + '</td>' +
                     '<td>' + formatText + '</td>' +
+                    '<td>' + logicText + '</td>' +
                     '<td>' + sizeText + '</td>' +
                     '<td>' + btnHtml + '</td>';
 

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -113,6 +113,15 @@ the Free Software Foundation, either version 3 of the License, or
                         </div>
                     </div>
 
+                    <div class="selectContainer" style="margin-top: 1.5em;">
+                        <label class="selectLabel" for="AmbilightExtractionMethod">Extraction logic</label>
+                        <select is="emby-select" id="AmbilightExtractionMethod" class="emby-select-withcolor emby-select">
+                            <option value="edge_weighted">Sobel edge-weighted extraction</option>
+                            <option value="linear_light_average">Linear-light averaging</option>
+                        </select>
+                        <div class="fieldDescription">How each LED zone's color is derived from the picture. "Sobel edge-weighted extraction" (default) biases each zone toward high-contrast pixels and rescales zones by relative brightness, which keeps the strip lively but makes dark scenes read brighter than the picture. "Linear-light averaging" takes a plain mean of every pixel in the zone in linear light, so a dark zone averages dark and a black frame produces black LEDs. Changing this requires re-extracting existing items — previously extracted files are not converted.</div>
+                    </div>
+
                     <div class="inputContainer" style="margin-top: 1.5em;">
                         <label class="inputLabel inputLabelUnfocused" for="AmbilightDataFolder">Ambilight data folder</label>
                         <div style="display: flex; gap: 0.5em; align-items: center;">
@@ -312,6 +321,7 @@ the Free Software Foundation, either version 3 of the License, or
                         document.querySelector('#AmbilightBottomLedCount').value = config.AmbilightBottomLedCount;
                         document.querySelector('#AmbilightLeftLedCount').value = config.AmbilightLeftLedCount;
                         document.querySelector('#AmbilightRightLedCount').value = config.AmbilightRightLedCount;
+                        document.querySelector('#AmbilightExtractionMethod').value = config.AmbilightExtractionMethod || 'edge_weighted';
                         document.querySelector('#AmbilightGamma').value = config.AmbilightGamma;
                         document.querySelector('#AmbilightSaturation').value = config.AmbilightSaturation;
 
@@ -347,6 +357,7 @@ the Free Software Foundation, either version 3 of the License, or
                     config.AmbilightBottomLedCount = document.querySelector('#AmbilightBottomLedCount').value;
                     config.AmbilightLeftLedCount = document.querySelector('#AmbilightLeftLedCount').value;
                     config.AmbilightRightLedCount = document.querySelector('#AmbilightRightLedCount').value;
+                    config.AmbilightExtractionMethod = document.querySelector('#AmbilightExtractionMethod').value || 'edge_weighted';
                     config.AmbilightGamma = document.querySelector('#AmbilightGamma').value;
                     config.AmbilightSaturation = document.querySelector('#AmbilightSaturation').value;
 

--- a/PluginConfiguration.cs
+++ b/PluginConfiguration.cs
@@ -31,6 +31,14 @@ namespace Jellyfin.Plugin.Ambilight
         public int AmbilightBottomLedCount { get; set; } = 89;
         public int AmbilightLeftLedCount { get; set; } = 49;
         public int AmbilightRightLedCount { get; set; } = 49;
+
+        /// <summary>
+        /// Which per-zone extraction logic to use when creating binary files.
+        /// "edge_weighted" (default) biases each zone toward high-contrast pixels with Sobel edge
+        /// detection and rescales by relative luminance; "linear_light_average" takes a plain mean of
+        /// every pixel in linear light. Changing this requires re-extracting existing items.
+        /// </summary>
+        public string AmbilightExtractionMethod { get; set; } = "edge_weighted";
         // Ambilight Visual Settings (global preferences)
         public double AmbilightSyncLeadSeconds { get; set; } = 0.2;
         /// <summary>

--- a/Services/Amb3Format.cs
+++ b/Services/Amb3Format.cs
@@ -57,6 +57,17 @@ public static class Amb3Format
     public const byte QualityMedium = 1;
     public const byte QualityLow = 2;
 
+    // Extraction logic — which per-zone color algorithm produced the file.
+    // Stored in the first reserved header byte; 0 is the historical default so files written
+    // before this field existed (all-zero reserved bytes) correctly read as edge-weighted.
+    public const byte ExtractionLogicEdgeWeighted = 0;
+    public const byte ExtractionLogicLinearLightAverage = 1;
+
+    // Byte offset of the extraction_logic field within the header:
+    // magic(4) + version(1) + flags(4) + duration(8) + frames(8) + fps(4) + leds(8)
+    // + color_fmt(1) + compression(1) + quality(1) + colorspace(1) + index_offset(8) + chunk_count(4) = 53
+    public const int ExtractionLogicHeaderOffset = 53;
+
     // Index magic
     public static readonly byte[] IndexMagic = Encoding.ASCII.GetBytes("IDX3");
 
@@ -85,7 +96,8 @@ public static class Amb3Format
         byte compression,
         byte qualityLevel,
         ulong indexOffset,
-        uint chunkCount)
+        uint chunkCount,
+        byte extractionLogic = ExtractionLogicEdgeWeighted)
     {
         // magic
         w.Write((byte)'A');
@@ -119,8 +131,43 @@ public static class Amb3Format
         w.Write(indexOffset);
         // chunk_count (4 bytes)
         w.Write(chunkCount);
-        // reserved (32 bytes)
-        w.Write(new byte[32]);
+        // reserved (32 bytes) — first byte carries extraction_logic, rest zero
+        w.Write(extractionLogic);
+        w.Write(new byte[31]);
+    }
+
+    /// <summary>
+    /// Reads the extraction_logic byte from an AMb3 file header. Returns null if the file is
+    /// missing, too short, or not an AMb3 file. Files predating this field read back as
+    /// <see cref="ExtractionLogicEdgeWeighted"/> (0), which matches their actual behaviour.
+    /// </summary>
+    public static byte? ReadExtractionLogic(string binPath)
+    {
+        try
+        {
+            if (!File.Exists(binPath))
+                return null;
+
+            using var fs = File.OpenRead(binPath);
+            var head = new byte[ExtractionLogicHeaderOffset + 1];
+            int read = 0;
+            while (read < head.Length)
+            {
+                int n = fs.Read(head, read, head.Length - read);
+                if (n <= 0)
+                    break;
+                read += n;
+            }
+
+            if (read < head.Length || !IsAm3Magic(head.AsSpan(0, 4)))
+                return null;
+
+            return head[ExtractionLogicHeaderOffset];
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     public static void BackpatchHeaderIndexOffset(Stream stream, ulong indexOffset)

--- a/Services/AmbilightInProcessExtractor.cs
+++ b/Services/AmbilightInProcessExtractor.cs
@@ -361,7 +361,8 @@ public sealed class AmbilightInProcessExtractor
                 compression: Amb3Format.CompressionDeflate,
                 qualityLevel: Amb3Format.QualityHigh,
                 indexOffset: 0, // backpatched after index is written
-                chunkCount: 0); // backpatched after all chunks written
+                chunkCount: 0, // backpatched after all chunks written
+                extractionLogic: ExtractionLogicFactory.ToFormatCode(cfg.AmbilightExtractionMethod));
 
             ulong frameIndex = 0;
             var zoning = zones.ToArray();

--- a/Services/AmbilightInProcessExtractor.cs
+++ b/Services/AmbilightInProcessExtractor.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Ambilight.Services.Extraction;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Ambilight.Services;
@@ -292,6 +293,13 @@ public sealed class AmbilightInProcessExtractor
                 return false;
             }
 
+            // Select the per-zone color algorithm chosen in the plugin configuration.
+            var extractionLogic = ExtractionLogicFactory.Create(cfg.AmbilightExtractionMethod);
+            if (cfg.Debug)
+            {
+                _logger.LogInformation("[Ambilight] Extractor: using extraction logic {Logic}", extractionLogic.GetType().Name);
+            }
+
             // Build ffmpeg arguments with hardware acceleration
             string ffmpegArgs = BuildFfmpegArguments(videoPath);
             
@@ -494,7 +502,7 @@ public sealed class AmbilightInProcessExtractor
                 ulong tsUs = (ulong)(frameIndex * 1_000_000.0 / fps);
 
                 // Compute colors for each zone
-                ComputeFrameColors(frameBuffer, ExtractWidth, ExtractHeight, zoning, zoneColors);
+                extractionLogic.ComputeFrameColors(frameBuffer, ExtractWidth, ExtractHeight, zoning, zoneColors);
 
                 // Copy zone colors ( BinaryWriter writes from the array reference,
                 // and we reuse zoneColors, so we need our own copy per frame)
@@ -691,233 +699,6 @@ public sealed class AmbilightInProcessExtractor
         }
 
         return zones;
-    }
-
-    private static void ComputeFrameColors(
-        byte[] frame,
-        int width,
-        int height,
-        (int x1, int y1, int x2, int y2)[] zones,
-        byte[] output)
-    {
-        const int bytesPerLed = 3;
-
-        // First pass: extract colors and luminances
-        var zoneColors = new (byte r, byte g, byte b)[zones.Length];
-        var zoneLuminances = new float[zones.Length];
-        double totalLuminance = 0.0;
-        int validZones = 0;
-
-        for (int i = 0; i < zones.Length; i++)
-        {
-            var (x1, y1, x2, y2) = zones[i];
-            x1 = Math.Clamp(x1, 0, width);
-            x2 = Math.Clamp(x2, 0, width);
-            y1 = Math.Clamp(y1, 0, height);
-            y2 = Math.Clamp(y2, 0, height);
-            if (x2 <= x1 || y2 <= y1)
-            {
-                zoneColors[i] = (0, 0, 0);
-                zoneLuminances[i] = 0f;
-                continue;
-            }
-
-            var (rOut, gOut, bOut, lum) = ExtractEdgeDominantColor(frame, width, height, x1, y1, x2, y2);
-            zoneColors[i] = (rOut, gOut, bOut);
-            zoneLuminances[i] = lum;
-            totalLuminance += lum;
-            validZones++;
-        }
-
-        // Compute global average luminance
-        float globalAvgLum = validZones > 0 ? (float)(totalLuminance / validZones) : 0f;
-
-        // Second pass: scale RGB by zone luminance relative to global average
-        for (int i = 0; i < zones.Length; i++)
-        {
-            int outBase = i * bytesPerLed;
-
-            if (globalAvgLum <= 0.01f || zoneLuminances[i] <= 0.01f)
-            {
-                // Dark frame or dark zone — keep original color (will be dim anyway)
-                output[outBase] = zoneColors[i].r;
-                output[outBase + 1] = zoneColors[i].g;
-                output[outBase + 2] = zoneColors[i].b;
-                continue;
-            }
-
-            float rawScale = zoneLuminances[i] / globalAvgLum;
-            float scale = (float)Math.Clamp(MathF.Pow(rawScale, 0.45f), 0.25f, 3.0f);
-            float maxCh = Math.Max(zoneColors[i].r, Math.Max(zoneColors[i].g, zoneColors[i].b));
-            float finalScale = maxCh > 0 ? Math.Min(scale, 255f / maxCh) : scale;
-            output[outBase] = (byte)Math.Clamp((int)Math.Round(zoneColors[i].r * finalScale), 0, 255);
-            output[outBase + 1] = (byte)Math.Clamp((int)Math.Round(zoneColors[i].g * finalScale), 0, 255);
-            output[outBase + 2] = (byte)Math.Clamp((int)Math.Round(zoneColors[i].b * finalScale), 0, 255);
-        }
-    }
-
-    /// <summary>
-    /// Extract color from a zone using edge detection + center weighting, matching the Rust extractor.
-    /// Uses Sobel edge detection (simpler than Canny but similar results) combined with Gaussian center weighting.
-    /// </summary>
-    private static (byte r, byte g, byte b, float luminance) ExtractEdgeDominantColor(
-        byte[] frame,
-        int frameWidth,
-        int frameHeight,
-        int x1,
-        int y1,
-        int x2,
-        int y2)
-    {
-        int w = x2 - x1;
-        int h = y2 - y1;
-
-        if (w <= 0 || h <= 0)
-        {
-            return (0, 0, 0, 0f);
-        }
-
-        // Compute grayscale and Sobel edge strength for the ROI
-        var edgeStrength = new float[h, w];
-        float maxEdge = 0.0f;
-        double lumSum = 0.0;
-        int pixelCount = 0;
-
-        for (int yy = 0; yy < h; yy++)
-        {
-            for (int xx = 0; xx < w; xx++)
-            {
-                int fx = x1 + xx;
-                int fy = y1 + yy;
-
-                // Sobel operators for edge detection
-                float gx = 0.0f;
-                float gy = 0.0f;
-
-                // 3x3 Sobel kernel (sample neighbors if available)
-                for (int dy = -1; dy <= 1; dy++)
-                {
-                    for (int dx = -1; dx <= 1; dx++)
-                    {
-                        int nx = Math.Clamp(fx + dx, x1, x2 - 1);
-                        int ny = Math.Clamp(fy + dy, y1, y2 - 1);
-                        int idx = (ny * frameWidth + nx) * 3;
-
-                        // Grayscale approximation: 0.299*R + 0.587*G + 0.114*B
-                        float gray = frame[idx] * 0.299f + frame[idx + 1] * 0.587f + frame[idx + 2] * 0.114f;
-
-                        // Sobel X kernel: [-1 0 1; -2 0 2; -1 0 1]
-                        if (dx == -1) gx -= gray * (dy == 0 ? 2.0f : 1.0f);
-                        else if (dx == 1) gx += gray * (dy == 0 ? 2.0f : 1.0f);
-
-                        // Sobel Y kernel: [-1 -2 -1; 0 0 0; 1 2 1]
-                        if (dy == -1) gy -= gray * (dx == 0 ? 2.0f : 1.0f);
-                        else if (dy == 1) gy += gray * (dx == 0 ? 2.0f : 1.0f);
-                    }
-                }
-
-                float magnitude = MathF.Sqrt(gx * gx + gy * gy);
-                edgeStrength[yy, xx] = magnitude;
-                maxEdge = Math.Max(maxEdge, magnitude);
-
-                // Accumulate luminance for zone brightness
-                int centerIdx = (fy * frameWidth + fx) * 3;
-                lumSum += frame[centerIdx] * 0.2126 + frame[centerIdx + 1] * 0.7152 + frame[centerIdx + 2] * 0.0722;
-                pixelCount++;
-            }
-        }
-
-        float zoneLuminance = pixelCount > 0 ? (float)(lumSum / pixelCount) : 0f;
-
-        // Normalize edge strengths to 0-1 range
-        if (maxEdge > 0.0f)
-        {
-            for (int yy = 0; yy < h; yy++)
-            {
-                for (int xx = 0; xx < w; xx++)
-                {
-                    edgeStrength[yy, xx] /= maxEdge;
-                }
-            }
-        }
-
-        // Compute weighted average: 70% edge weight + 30% center weight (matching Rust)
-        double rSum = 0.0, gSum = 0.0, bSum = 0.0;
-        double totalWeight = 0.0;
-
-        int centerX = w / 2;
-        int centerY = h / 2;
-        int minSize = Math.Min(w, h);
-        double sigma = Math.Max(minSize / 4.0, 1.0);
-        double sigmaSq2 = 2.0 * sigma * sigma;
-
-        for (int yy = 0; yy < h; yy++)
-        {
-            for (int xx = 0; xx < w; xx++)
-            {
-                // Edge weight (0-1)
-                double edgeWeight = edgeStrength[yy, xx];
-
-                // Center weight (Gaussian)
-                double dx = xx - centerX;
-                double dy = yy - centerY;
-                double distSq = dx * dx + dy * dy;
-                double centerWeight = Math.Exp(-distSq / sigmaSq2);
-
-                // Combined: 70% edge, 30% center (matching Rust implementation)
-                double weight = Math.Max(edgeWeight * 0.7 + centerWeight * 0.3, 0.01);
-
-                int fx = x1 + xx;
-                int fy = y1 + yy;
-                int idx = (fy * frameWidth + fx) * 3;
-
-                byte r = frame[idx];
-                byte g = frame[idx + 1];
-                byte b = frame[idx + 2];
-
-                rSum += r * weight;
-                gSum += g * weight;
-                bSum += b * weight;
-                totalWeight += weight;
-            }
-        }
-
-        if (totalWeight > 0.0)
-        {
-            return (
-                (byte)Math.Clamp((int)Math.Round(rSum / totalWeight), 0, 255),
-                (byte)Math.Clamp((int)Math.Round(gSum / totalWeight), 0, 255),
-                (byte)Math.Clamp((int)Math.Round(bSum / totalWeight), 0, 255),
-                zoneLuminance
-            );
-        }
-
-        // Fallback: simple average
-        double rAvg = 0.0, gAvg = 0.0, bAvg = 0.0;
-        int count = 0;
-        for (int yy = y1; yy < y2; yy++)
-        {
-            for (int xx = x1; xx < x2; xx++)
-            {
-                int idx = (yy * frameWidth + xx) * 3;
-                rAvg += frame[idx];
-                gAvg += frame[idx + 1];
-                bAvg += frame[idx + 2];
-                count++;
-            }
-        }
-
-        if (count > 0)
-        {
-            return (
-                (byte)(rAvg / count),
-                (byte)(gAvg / count),
-                (byte)(bAvg / count),
-                zoneLuminance
-            );
-        }
-
-        return (0, 0, 0, 0f);
     }
 }
 

--- a/Services/AmbilightInProcessPlayer.cs
+++ b/Services/AmbilightInProcessPlayer.cs
@@ -475,6 +475,13 @@ public sealed class AmbilightInProcessPlayer : IDisposable
             float gammaRed = ClampF((float)cfg.AmbilightGammaRed, 0.1f, 5.0f);
             float gammaGreen = ClampF((float)cfg.AmbilightGammaGreen, 0.1f, 5.0f);
             float gammaBlue = ClampF((float)cfg.AmbilightGammaBlue, 0.1f, 5.0f);
+
+            // The tone curve depends on how the file was extracted (stored in the AMb3 header).
+            // Linear-light-averaged files are already picture-faithful, so we apply gamma directly
+            // instead of the scene-adaptive lift. AMb2 / older files read back as edge-weighted and
+            // keep the original behaviour.
+            byte extractionLogicCode = Amb3Format.ReadExtractionLogic(binPath) ?? Amb3Format.ExtractionLogicEdgeWeighted;
+            bool linearLightExtraction = extractionLogicCode == Amb3Format.ExtractionLogicLinearLightAverage;
             int inputPosition = mapping.InputPosition;
             int gapLength = mapping.GapLength;
             int gapPosition = mapping.GapPosition;
@@ -639,23 +646,35 @@ public sealed class AmbilightInProcessPlayer : IDisposable
                 }
                 prevRawFrame = raw;
 
-                // avg luminance
-                float sumLum = 0f;
-                int countPix = 0;
-                int idx = 0;
-                while (idx + 2 < raw.Length)
+                // Output gamma exponent for this frame. For linear-light files, apply the user's
+                // gamma directly, so exponents above 1 darken and dark scenes stay dark. Otherwise
+                // invert it into a scene-adaptive lift that brightens dark scenes, matching the
+                // original edge-weighted behaviour. The mean-luminance pass only feeds that lift, so
+                // it is skipped for linear-light files.
+                float outputGamma;
+                if (linearLightExtraction)
                 {
-                    float r = raw[idx];
-                    float g = raw[idx + 1];
-                    float b = raw[idx + 2];
-                    float lum = 0.2126f * r + 0.7152f * g + 0.0722f * b;
-                    sumLum += lum;
-                    countPix++;
-                    idx += bytesPerLed;
+                    outputGamma = ClampF(gammaBase, 0.1f, 5.0f);
                 }
-                float avgLum = countPix > 0 ? sumLum / countPix : 0f;
-                float gammaAdj = ClampF(gammaBase * (1.0f - (avgLum / 255.0f) * 0.6f), 1.0f, 3.0f);
-                float invGamma = 1.0f / gammaAdj;
+                else
+                {
+                    float sumLum = 0f;
+                    int countPix = 0;
+                    int idx = 0;
+                    while (idx + 2 < raw.Length)
+                    {
+                        float r = raw[idx];
+                        float g = raw[idx + 1];
+                        float b = raw[idx + 2];
+                        float lum = 0.2126f * r + 0.7152f * g + 0.0722f * b;
+                        sumLum += lum;
+                        countPix++;
+                        idx += bytesPerLed;
+                    }
+                    float avgLum = countPix > 0 ? sumLum / countPix : 0f;
+                    float gammaAdj = ClampF(gammaBase * (1.0f - (avgLum / 255.0f) * 0.6f), 1.0f, 3.0f);
+                    outputGamma = 1.0f / gammaAdj;
+                }
 
                 float frameDtS;
                 if (frameIndex == 0)
@@ -715,9 +734,9 @@ public sealed class AmbilightInProcessPlayer : IDisposable
                     float gSat = ClampF(avgIntensity + (gLin - avgIntensity) * sUser, 0.0f, 1.0f);
                     float bSat = ClampF(avgIntensity + (bLin - avgIntensity) * sUser, 0.0f, 1.0f);
 
-                    float rG = ClampF((float)MathF.Pow(rSat, invGamma), 0.0f, 1.0f);
-                    float gG = ClampF((float)MathF.Pow(gSat, invGamma), 0.0f, 1.0f);
-                    float bG = ClampF((float)MathF.Pow(bSat, invGamma), 0.0f, 1.0f);
+                    float rG = ClampF((float)MathF.Pow(rSat, outputGamma), 0.0f, 1.0f);
+                    float gG = ClampF((float)MathF.Pow(gSat, outputGamma), 0.0f, 1.0f);
+                    float bG = ClampF((float)MathF.Pow(bSat, outputGamma), 0.0f, 1.0f);
 
                     float rF = rG * 255.0f;
                     float gF = gG * 255.0f;

--- a/Services/Extraction/EdgeWeightedExtractionLogic.cs
+++ b/Services/Extraction/EdgeWeightedExtractionLogic.cs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Jellyfin Ambilight Contributors
+// This file is part of Jellyfin Ambilight Plugin.
+// Jellyfin Ambilight Plugin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+
+namespace Jellyfin.Plugin.Ambilight.Services.Extraction;
+
+/// <summary>
+/// Picks each zone color with Sobel edge detection combined with Gaussian center weighting
+/// (matching the Rust extractor), then rescales every zone's brightness relative to the frame's
+/// average luminance. This biases each zone toward high-contrast pixels and lifts dark zones,
+/// which keeps the strip lively but makes dark scenes read brighter than the picture.
+/// This is the historical default behaviour.
+/// </summary>
+public sealed class EdgeWeightedExtractionLogic : IExtractionLogic
+{
+    public void ComputeFrameColors(
+        byte[] frame,
+        int width,
+        int height,
+        (int x1, int y1, int x2, int y2)[] zones,
+        byte[] output)
+    {
+        const int bytesPerLed = 3;
+
+        // First pass: extract colors and luminances
+        var zoneColors = new (byte r, byte g, byte b)[zones.Length];
+        var zoneLuminances = new float[zones.Length];
+        double totalLuminance = 0.0;
+        int validZones = 0;
+
+        for (int i = 0; i < zones.Length; i++)
+        {
+            var (x1, y1, x2, y2) = zones[i];
+            x1 = Math.Clamp(x1, 0, width);
+            x2 = Math.Clamp(x2, 0, width);
+            y1 = Math.Clamp(y1, 0, height);
+            y2 = Math.Clamp(y2, 0, height);
+            if (x2 <= x1 || y2 <= y1)
+            {
+                zoneColors[i] = (0, 0, 0);
+                zoneLuminances[i] = 0f;
+                continue;
+            }
+
+            var (rOut, gOut, bOut, lum) = ExtractEdgeDominantColor(frame, width, height, x1, y1, x2, y2);
+            zoneColors[i] = (rOut, gOut, bOut);
+            zoneLuminances[i] = lum;
+            totalLuminance += lum;
+            validZones++;
+        }
+
+        // Compute global average luminance
+        float globalAvgLum = validZones > 0 ? (float)(totalLuminance / validZones) : 0f;
+
+        // Second pass: scale RGB by zone luminance relative to global average
+        for (int i = 0; i < zones.Length; i++)
+        {
+            int outBase = i * bytesPerLed;
+
+            if (globalAvgLum <= 0.01f || zoneLuminances[i] <= 0.01f)
+            {
+                // Dark frame or dark zone — keep original color (will be dim anyway)
+                output[outBase] = zoneColors[i].r;
+                output[outBase + 1] = zoneColors[i].g;
+                output[outBase + 2] = zoneColors[i].b;
+                continue;
+            }
+
+            float rawScale = zoneLuminances[i] / globalAvgLum;
+            float scale = (float)Math.Clamp(MathF.Pow(rawScale, 0.45f), 0.25f, 3.0f);
+            float maxCh = Math.Max(zoneColors[i].r, Math.Max(zoneColors[i].g, zoneColors[i].b));
+            float finalScale = maxCh > 0 ? Math.Min(scale, 255f / maxCh) : scale;
+            output[outBase] = (byte)Math.Clamp((int)Math.Round(zoneColors[i].r * finalScale), 0, 255);
+            output[outBase + 1] = (byte)Math.Clamp((int)Math.Round(zoneColors[i].g * finalScale), 0, 255);
+            output[outBase + 2] = (byte)Math.Clamp((int)Math.Round(zoneColors[i].b * finalScale), 0, 255);
+        }
+    }
+
+    /// <summary>
+    /// Extract color from a zone using edge detection + center weighting, matching the Rust extractor.
+    /// Uses Sobel edge detection (simpler than Canny but similar results) combined with Gaussian center weighting.
+    /// </summary>
+    private static (byte r, byte g, byte b, float luminance) ExtractEdgeDominantColor(
+        byte[] frame,
+        int frameWidth,
+        int frameHeight,
+        int x1,
+        int y1,
+        int x2,
+        int y2)
+    {
+        int w = x2 - x1;
+        int h = y2 - y1;
+
+        if (w <= 0 || h <= 0)
+        {
+            return (0, 0, 0, 0f);
+        }
+
+        // Compute grayscale and Sobel edge strength for the ROI
+        var edgeStrength = new float[h, w];
+        float maxEdge = 0.0f;
+        double lumSum = 0.0;
+        int pixelCount = 0;
+
+        for (int yy = 0; yy < h; yy++)
+        {
+            for (int xx = 0; xx < w; xx++)
+            {
+                int fx = x1 + xx;
+                int fy = y1 + yy;
+
+                // Sobel operators for edge detection
+                float gx = 0.0f;
+                float gy = 0.0f;
+
+                // 3x3 Sobel kernel (sample neighbors if available)
+                for (int dy = -1; dy <= 1; dy++)
+                {
+                    for (int dx = -1; dx <= 1; dx++)
+                    {
+                        int nx = Math.Clamp(fx + dx, x1, x2 - 1);
+                        int ny = Math.Clamp(fy + dy, y1, y2 - 1);
+                        int idx = (ny * frameWidth + nx) * 3;
+
+                        // Grayscale approximation: 0.299*R + 0.587*G + 0.114*B
+                        float gray = frame[idx] * 0.299f + frame[idx + 1] * 0.587f + frame[idx + 2] * 0.114f;
+
+                        // Sobel X kernel: [-1 0 1; -2 0 2; -1 0 1]
+                        if (dx == -1) gx -= gray * (dy == 0 ? 2.0f : 1.0f);
+                        else if (dx == 1) gx += gray * (dy == 0 ? 2.0f : 1.0f);
+
+                        // Sobel Y kernel: [-1 -2 -1; 0 0 0; 1 2 1]
+                        if (dy == -1) gy -= gray * (dx == 0 ? 2.0f : 1.0f);
+                        else if (dy == 1) gy += gray * (dx == 0 ? 2.0f : 1.0f);
+                    }
+                }
+
+                float magnitude = MathF.Sqrt(gx * gx + gy * gy);
+                edgeStrength[yy, xx] = magnitude;
+                maxEdge = Math.Max(maxEdge, magnitude);
+
+                // Accumulate luminance for zone brightness
+                int centerIdx = (fy * frameWidth + fx) * 3;
+                lumSum += frame[centerIdx] * 0.2126 + frame[centerIdx + 1] * 0.7152 + frame[centerIdx + 2] * 0.0722;
+                pixelCount++;
+            }
+        }
+
+        float zoneLuminance = pixelCount > 0 ? (float)(lumSum / pixelCount) : 0f;
+
+        // Normalize edge strengths to 0-1 range
+        if (maxEdge > 0.0f)
+        {
+            for (int yy = 0; yy < h; yy++)
+            {
+                for (int xx = 0; xx < w; xx++)
+                {
+                    edgeStrength[yy, xx] /= maxEdge;
+                }
+            }
+        }
+
+        // Compute weighted average: 70% edge weight + 30% center weight (matching Rust)
+        double rSum = 0.0, gSum = 0.0, bSum = 0.0;
+        double totalWeight = 0.0;
+
+        int centerX = w / 2;
+        int centerY = h / 2;
+        int minSize = Math.Min(w, h);
+        double sigma = Math.Max(minSize / 4.0, 1.0);
+        double sigmaSq2 = 2.0 * sigma * sigma;
+
+        for (int yy = 0; yy < h; yy++)
+        {
+            for (int xx = 0; xx < w; xx++)
+            {
+                // Edge weight (0-1)
+                double edgeWeight = edgeStrength[yy, xx];
+
+                // Center weight (Gaussian)
+                double dx = xx - centerX;
+                double dy = yy - centerY;
+                double distSq = dx * dx + dy * dy;
+                double centerWeight = Math.Exp(-distSq / sigmaSq2);
+
+                // Combined: 70% edge, 30% center (matching Rust implementation)
+                double weight = Math.Max(edgeWeight * 0.7 + centerWeight * 0.3, 0.01);
+
+                int fx = x1 + xx;
+                int fy = y1 + yy;
+                int idx = (fy * frameWidth + fx) * 3;
+
+                byte r = frame[idx];
+                byte g = frame[idx + 1];
+                byte b = frame[idx + 2];
+
+                rSum += r * weight;
+                gSum += g * weight;
+                bSum += b * weight;
+                totalWeight += weight;
+            }
+        }
+
+        if (totalWeight > 0.0)
+        {
+            return (
+                (byte)Math.Clamp((int)Math.Round(rSum / totalWeight), 0, 255),
+                (byte)Math.Clamp((int)Math.Round(gSum / totalWeight), 0, 255),
+                (byte)Math.Clamp((int)Math.Round(bSum / totalWeight), 0, 255),
+                zoneLuminance
+            );
+        }
+
+        // Fallback: simple average
+        double rAvg = 0.0, gAvg = 0.0, bAvg = 0.0;
+        int count = 0;
+        for (int yy = y1; yy < y2; yy++)
+        {
+            for (int xx = x1; xx < x2; xx++)
+            {
+                int idx = (yy * frameWidth + xx) * 3;
+                rAvg += frame[idx];
+                gAvg += frame[idx + 1];
+                bAvg += frame[idx + 2];
+                count++;
+            }
+        }
+
+        if (count > 0)
+        {
+            return (
+                (byte)(rAvg / count),
+                (byte)(gAvg / count),
+                (byte)(bAvg / count),
+                zoneLuminance
+            );
+        }
+
+        return (0, 0, 0, 0f);
+    }
+}

--- a/Services/Extraction/ExtractionLogicFactory.cs
+++ b/Services/Extraction/ExtractionLogicFactory.cs
@@ -26,4 +26,24 @@ public static class ExtractionLogicFactory
         LinearLightAverage => new LinearLightAverageExtractionLogic(),
         _ => new EdgeWeightedExtractionLogic(),
     };
+
+    /// <summary>
+    /// Maps a config method value to the byte code stored in the AMb3 header.
+    /// Unknown/missing values map to the default edge-weighted code.
+    /// </summary>
+    public static byte ToFormatCode(string? method) => method switch
+    {
+        LinearLightAverage => Amb3Format.ExtractionLogicLinearLightAverage,
+        _ => Amb3Format.ExtractionLogicEdgeWeighted,
+    };
+
+    /// <summary>
+    /// Human-readable label for an extraction-logic header byte, for display on the extraction page.
+    /// </summary>
+    public static string DisplayName(byte formatCode) => formatCode switch
+    {
+        Amb3Format.ExtractionLogicLinearLightAverage => "Linear-light averaging",
+        Amb3Format.ExtractionLogicEdgeWeighted => "Sobel edge-weighted",
+        _ => "Unknown",
+    };
 }

--- a/Services/Extraction/ExtractionLogicFactory.cs
+++ b/Services/Extraction/ExtractionLogicFactory.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Jellyfin Ambilight Contributors
+// This file is part of Jellyfin Ambilight Plugin.
+// Jellyfin Ambilight Plugin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+namespace Jellyfin.Plugin.Ambilight.Services.Extraction;
+
+/// <summary>
+/// Resolves the configured <see cref="PluginConfiguration.AmbilightExtractionMethod"/> value to a
+/// concrete <see cref="IExtractionLogic"/>. Unknown or missing values fall back to the default
+/// edge-weighted logic.
+/// </summary>
+public static class ExtractionLogicFactory
+{
+    /// <summary>Config value for the historical Sobel edge-weighted extraction (default).</summary>
+    public const string EdgeWeighted = "edge_weighted";
+
+    /// <summary>Config value for the linear-light averaging extraction.</summary>
+    public const string LinearLightAverage = "linear_light_average";
+
+    public static IExtractionLogic Create(string? method) => method switch
+    {
+        LinearLightAverage => new LinearLightAverageExtractionLogic(),
+        _ => new EdgeWeightedExtractionLogic(),
+    };
+}

--- a/Services/Extraction/IExtractionLogic.cs
+++ b/Services/Extraction/IExtractionLogic.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Jellyfin Ambilight Contributors
+// This file is part of Jellyfin Ambilight Plugin.
+// Jellyfin Ambilight Plugin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+namespace Jellyfin.Plugin.Ambilight.Services.Extraction;
+
+/// <summary>
+/// Turns a single decoded RGB24 frame into one color per LED zone.
+/// Implementations own the full per-frame color algorithm so the extractor plumbing
+/// (ffmpeg decoding, chaptering, AMb3 serialization) stays agnostic about how zone
+/// colors are derived. Which implementation is used is chosen by
+/// <see cref="PluginConfiguration.AmbilightExtractionMethod"/>.
+/// </summary>
+public interface IExtractionLogic
+{
+    /// <summary>
+    /// Compute one RGB color per zone and write them into <paramref name="output"/> as
+    /// consecutive RGB byte triplets (3 bytes per zone, in zone order).
+    /// </summary>
+    /// <param name="frame">Packed RGB24 pixels for the whole frame (width * height * 3 bytes).</param>
+    /// <param name="width">Frame width in pixels.</param>
+    /// <param name="height">Frame height in pixels.</param>
+    /// <param name="zones">Per-LED pixel rectangles as (x1, y1, x2, y2), half-open on x2/y2.</param>
+    /// <param name="output">Destination buffer, at least zones.Length * 3 bytes long.</param>
+    void ComputeFrameColors(
+        byte[] frame,
+        int width,
+        int height,
+        (int x1, int y1, int x2, int y2)[] zones,
+        byte[] output);
+}

--- a/Services/Extraction/LinearLightAverageExtractionLogic.cs
+++ b/Services/Extraction/LinearLightAverageExtractionLogic.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Jellyfin Ambilight Contributors
+// This file is part of Jellyfin Ambilight Plugin.
+// Jellyfin Ambilight Plugin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+
+namespace Jellyfin.Plugin.Ambilight.Services.Extraction;
+
+/// <summary>
+/// Computes each zone as a plain, unweighted mean of every pixel in the zone, taken in linear
+/// light. This is the picture-extending behaviour: a dark zone averages dark, and a black frame
+/// produces black LEDs. There is no edge weighting and no cross-zone brightness rescaling.
+/// </summary>
+public sealed class LinearLightAverageExtractionLogic : IExtractionLogic
+{
+    // sRGB transfer function tables. Averaging must happen in linear light: because the sRGB
+    // encoding is concave, the mean of encoded values always decodes brighter than the true mean,
+    // and the error peaks on zones mixing dark pixels with highlights. HyperHDR does the same
+    // (ImageColorAveraging::calcMulticolorForLeds).
+    private static readonly float[] SrgbToLinear = BuildSrgbToLinear();
+
+    private static float[] BuildSrgbToLinear()
+    {
+        var lut = new float[256];
+        for (int i = 0; i < 256; i++)
+        {
+            float v = i / 255.0f;
+            lut[i] = v <= 0.04045f ? v / 12.92f : MathF.Pow((v + 0.055f) / 1.055f, 2.4f);
+        }
+        return lut;
+    }
+
+    private static byte LinearToSrgbByte(float linear)
+    {
+        linear = Math.Clamp(linear, 0.0f, 1.0f);
+        float encoded = linear <= 0.0031308f
+            ? linear * 12.92f
+            : 1.055f * MathF.Pow(linear, 1.0f / 2.4f) - 0.055f;
+        return (byte)Math.Clamp((int)MathF.Round(encoded * 255.0f), 0, 255);
+    }
+
+    public void ComputeFrameColors(
+        byte[] frame,
+        int width,
+        int height,
+        (int x1, int y1, int x2, int y2)[] zones,
+        byte[] output)
+    {
+        const int bytesPerLed = 3;
+
+        for (int i = 0; i < zones.Length; i++)
+        {
+            var (x1, y1, x2, y2) = zones[i];
+            x1 = Math.Clamp(x1, 0, width);
+            x2 = Math.Clamp(x2, 0, width);
+            y1 = Math.Clamp(y1, 0, height);
+            y2 = Math.Clamp(y2, 0, height);
+
+            int outBase = i * bytesPerLed;
+            if (x2 <= x1 || y2 <= y1)
+            {
+                output[outBase] = 0;
+                output[outBase + 1] = 0;
+                output[outBase + 2] = 0;
+                continue;
+            }
+
+            var (rOut, gOut, bOut) = ExtractLinearMeanColor(frame, width, x1, y1, x2, y2);
+            output[outBase] = rOut;
+            output[outBase + 1] = gOut;
+            output[outBase + 2] = bOut;
+        }
+    }
+
+    /// <summary>
+    /// Unweighted mean of every pixel in the zone, taken in linear light.
+    /// </summary>
+    private static (byte r, byte g, byte b) ExtractLinearMeanColor(
+        byte[] frame,
+        int frameWidth,
+        int x1,
+        int y1,
+        int x2,
+        int y2)
+    {
+        double rSum = 0.0, gSum = 0.0, bSum = 0.0;
+        int count = 0;
+
+        for (int yy = y1; yy < y2; yy++)
+        {
+            int rowBase = yy * frameWidth * 3;
+            for (int xx = x1; xx < x2; xx++)
+            {
+                int idx = rowBase + xx * 3;
+                rSum += SrgbToLinear[frame[idx]];
+                gSum += SrgbToLinear[frame[idx + 1]];
+                bSum += SrgbToLinear[frame[idx + 2]];
+                count++;
+            }
+        }
+
+        if (count == 0)
+        {
+            return (0, 0, 0);
+        }
+
+        return (
+            LinearToSrgbByte((float)(rSum / count)),
+            LinearToSrgbByte((float)(gSum / count)),
+            LinearToSrgbByte((float)(bSum / count))
+        );
+    }
+}

--- a/Services/Extraction/LinearLightAverageExtractionLogic.cs
+++ b/Services/Extraction/LinearLightAverageExtractionLogic.cs
@@ -19,8 +19,7 @@ public sealed class LinearLightAverageExtractionLogic : IExtractionLogic
 {
     // sRGB transfer function tables. Averaging must happen in linear light: because the sRGB
     // encoding is concave, the mean of encoded values always decodes brighter than the true mean,
-    // and the error peaks on zones mixing dark pixels with highlights. HyperHDR does the same
-    // (ImageColorAveraging::calcMulticolorForLeds).
+    // and the error peaks on zones mixing dark pixels with highlights.
     private static readonly float[] SrgbToLinear = BuildSrgbToLinear();
 
     private static float[] BuildSrgbToLinear()


### PR DESCRIPTION
## Summary

Using the current extraction logic and player configuration, dark scenes can produce overly bright LED colors compared to other ambilight-style software solutions. This PR addresses this issue by adding a second extraction logic alongside the existing one, selectable from the plugin config, and records which logic produced each binary so playback can adapt.

### Extraction logic abstraction
- New `IExtractionLogic` strategy so the extractor plumbing (ffmpeg decoding, chaptering, AMb3 serialization) stays agnostic about how zone colors are derived.
- `EdgeWeightedExtractionLogic` — the existing Sobel edge + Gaussian center weighting with relative-luminance rescaling (unchanged default).
- `LinearLightAverageExtractionLogic` — a plain unweighted mean of each zone's pixels taken in linear light, so dark zones average dark and black frames produce black LEDs.
- `ExtractionLogicFactory` maps the new `AmbilightExtractionMethod` config value to an implementation, defaulting to edge-weighted for unknown/missing values.
- Config page gains an **Extraction logic** dropdown (the only new configuration surface).

### Stored as metadata
- The chosen logic is recorded in the first reserved AMb3 header byte (`0` = edge-weighted, `1` = linear-light averaging). Value `0` is the historical default, so files written before this field read back correctly as edge-weighted. Header size and `ReadHeader` are unchanged.
- The status API exposes it, and the extraction table gains a **Logic** column so already-extracted binaries can be distinguished.

### Playback tone curve follows the extraction logic
- The player brightens every frame with a scene-adaptive gamma lift, which re-brightened linear-light output and erased its picture-faithful "dark stays dark" property — making both methods look alike.
- The player now reads the header byte and branches the per-frame tone curve: linear-light files apply the user's gamma directly (`pow(x, gamma)`, exponents above 1 darken) and skip the mean-luminance pass; edge-weighted / AMb2 / older files keep the existing lift. No new config option; already-extracted files benefit without re-extraction.

> [!NOTE]
> `AmbilightGamma` now darkens linear-light files instead of setting lift strength, so its `2.2` default reads dark for them — lower it (~`1.3`–`1.5`) for a more picture-faithful result.

## Notes
- Switching extraction method requires re-extracting existing items; previously extracted files are not converted.

## Example videos

### Edge-weighted extraction
https://github.com/user-attachments/assets/f8760265-5e4a-4812-b492-824e8f119a09

### Linear-light extraction (new)
https://github.com/user-attachments/assets/c333c15c-0803-4922-87ff-d0843ddc955d

